### PR TITLE
Make examples work again

### DIFF
--- a/examples/chromeBinary.dot
+++ b/examples/chromeBinary.dot
@@ -3,8 +3,7 @@ digraph chromeBinaryTest {
   imports="['chromium-phases']"
 
   input [data="./example.ejs"]
-  chromeBinary [version="323860", chromium="<path to chromium/src>", platform="linux"]
 
-  input -> ejsFabricator -> chromeBinary -> consoleOutput;
+  input -> ejsFabricator -> chromeBinary -> log;
 
 }

--- a/examples/regexReplace.dot
+++ b/examples/regexReplace.dot
@@ -1,8 +1,8 @@
 digraph experiment {
   imports="['trace-phases']";
 
-  input_w -> fileToBuffer -> gunzipAndDecode -> ejsFabricator -> regexReplace -> simplePerfer;
-  simplePerfer -> traceFilter -> traceTree -> tracePrettyPrint -> log;
+  input_w -> fileToBuffer -> gunzipAndDecode -> ejsFabricator -> regexReplace -> trace;
+  trace -> traceFilter -> traceTree -> tracePrettyPrint -> log;
   input_steps -> fileToBuffer;
 
   input_w [label="input", data="whitespace/example.ejs"];

--- a/lib/chromium-phases/chromium-phases.js
+++ b/lib/chromium-phases/chromium-phases.js
@@ -14,7 +14,7 @@
 // This is where all phases, related to Chromium checkout and build should live.
 // Interfacing with ninja, gclient, git cl? This is gthe spot.
 
-var phase = require('../../core/phase-register');
+var phase = require('../../core/register').phase;
 var types = require('../../core/types');
 
 var options = require('./chromium-options');

--- a/lib/chromium-phases/tests/chromium-phases.js
+++ b/lib/chromium-phases/tests/chromium-phases.js
@@ -38,8 +38,10 @@ ExecutableMock.prototype.toString = function() {
 }
 
 var ChromiumPhases = proxyquire('../chromium-phases', {
-  '../../core/phase-register': function(options, func) {
-    return { options: options, func: func };
+  '../../core/register': {
+    phase: function(options, func) {
+      return { options: options, func: func };
+    },
   },
   './executable': ExecutableMock,
   './chromium-options': {


### PR DESCRIPTION
`consoleOutput` and `simplePerfer` have been removed, which made the examples fail to run.