### PR TITLE
Call InitDependencyManager in telemetry scripts

### DIFF
--- a/telemetry/layout-perf.py
+++ b/telemetry/layout-perf.py
@@ -17,6 +17,11 @@ import sys;
 from telemetry.internal.browser import browser_options
 from telemetry.internal.browser import browser_finder
 
+# Initialize the dependency manager
+from telemetry.internal.util import binary_manager
+from chrome_telemetry_build import chromium_config
+binary_manager.InitDependencyManager(chromium_config.ChromiumConfig().client_config)
+
 from telemetry.timeline import tracing_category_filter
 from telemetry.timeline import tracing_options
 

--- a/telemetry/newBrowser.py
+++ b/telemetry/newBrowser.py
@@ -22,6 +22,11 @@ import telemetry.core
 from telemetry.internal.browser import browser_options
 from telemetry.internal.browser import browser_finder
 
+# Initialize the dependency manager
+from telemetry.internal.util import binary_manager
+from chrome_telemetry_build import chromium_config
+binary_manager.InitDependencyManager(chromium_config.ChromiumConfig().client_config)
+
 from telemetry.timeline import tracing_category_filter
 from telemetry.timeline import tracing_options
 

--- a/telemetry/perf.py
+++ b/telemetry/perf.py
@@ -17,6 +17,11 @@ import sys;
 from telemetry.internal.browser import browser_options
 from telemetry.internal.browser import browser_finder
 
+# Initialize the dependency manager
+from telemetry.internal.util import binary_manager
+from chrome_telemetry_build import chromium_config
+binary_manager.InitDependencyManager(chromium_config.ChromiumConfig().client_config)
+
 from telemetry.timeline import tracing_category_filter
 from telemetry.timeline import tracing_options
 

--- a/telemetry/save-no-style.py
+++ b/telemetry/save-no-style.py
@@ -16,6 +16,11 @@ import telemetry.core
 from telemetry.internal.browser import browser_options
 from telemetry.internal.browser import browser_finder
 
+# Initialize the dependency manager
+from telemetry.internal.util import binary_manager
+from chrome_telemetry_build import chromium_config
+binary_manager.InitDependencyManager(chromium_config.ChromiumConfig().client_config)
+
 from json import dumps
 
 options = browser_options.BrowserFinderOptions();

--- a/telemetry/save.py
+++ b/telemetry/save.py
@@ -16,6 +16,11 @@ import telemetry.core
 from telemetry.internal.browser import browser_options
 from telemetry.internal.browser import browser_finder
 
+# Initialize the dependency manager
+from telemetry.internal.util import binary_manager
+from chrome_telemetry_build import chromium_config
+binary_manager.InitDependencyManager(chromium_config.ChromiumConfig().client_config)
+
 from json import dumps
 
 options = browser_options.BrowserFinderOptions();

--- a/telemetry/style-perf.py
+++ b/telemetry/style-perf.py
@@ -17,6 +17,11 @@ import sys;
 from telemetry.internal.browser import browser_options
 from telemetry.internal.browser import browser_finder
 
+# Initialize the dependency manager
+from telemetry.internal.util import binary_manager
+from chrome_telemetry_build import chromium_config
+binary_manager.InitDependencyManager(chromium_config.ChromiumConfig().client_config)
+
 from telemetry.timeline import tracing_category_filter
 from telemetry.timeline import tracing_options
 


### PR DESCRIPTION
Recent versions of the Telemetry API need this call to work.