### PR TITLE
Update telemetry scripts (again)

### DIFF
--- a/lib/device-phases.js
+++ b/lib/device-phases.js
@@ -33,6 +33,7 @@ function expandPath(p) {
 if (options.chromium !== undefined) {
   chromium_path = expandPath(options.chromium);
   console.log("chromium path=%s", chromium_path);
+  process.env.PYTHONPATH += path.delimiter + chromium_path + '/tools/perf';
   process.env.PYTHONPATH += path.delimiter + chromium_path + '/tools/telemetry';
   process.env.PYTHONPATH += path.delimiter + chromium_path + '/tools';
 }

--- a/telemetry/layout-perf.py
+++ b/telemetry/layout-perf.py
@@ -45,6 +45,6 @@ with browserFactory.Create(options) as browser:
   tab.Navigate(args[0]);
   tab.WaitForDocumentReadyStateToBeComplete();
   tab.EvaluateJavaScript("(function() { document.documentElement.style.display = 'none'; return document.body.offsetTop; })()");
-  browser.platform.tracing_controller.Start(config)
+  browser.platform.tracing_controller.StartTracing(config)
   tab.EvaluateJavaScript("(function() { document.documentElement.style.display = 'block'; return document.body.offsetTop; })()");
-  browser.platform.tracing_controller.Stop().Serialize(sys.stdout);
+  browser.platform.tracing_controller.StopTracing().Serialize(sys.stdout);

--- a/telemetry/layout-perf.py
+++ b/telemetry/layout-perf.py
@@ -23,7 +23,7 @@ from chrome_telemetry_build import chromium_config
 binary_manager.InitDependencyManager(chromium_config.ChromiumConfig().client_config)
 
 from telemetry.timeline import tracing_category_filter
-from telemetry.timeline import tracing_options
+from telemetry.timeline import tracing_config
 
 from json import dumps
 
@@ -42,11 +42,11 @@ with browserFactory.Create(options) as browser:
     i.Close()
 
   category_filter = tracing_category_filter.TracingCategoryFilter()
-  options = tracing_options.TracingOptions()
-  options.enable_chrome_trace = True
+  config = tracing_config.TracingConfig()
+  config.enable_chrome_trace = True
   tab.Navigate(args[0]);
   tab.WaitForDocumentReadyStateToBeComplete();
   tab.EvaluateJavaScript("(function() { document.documentElement.style.display = 'none'; return document.body.offsetTop; })()");
-  browser.platform.tracing_controller.Start(options, category_filter);
+  browser.platform.tracing_controller.Start(config, category_filter)
   tab.EvaluateJavaScript("(function() { document.documentElement.style.display = 'block'; return document.body.offsetTop; })()");
   browser.platform.tracing_controller.Stop().Serialize(sys.stdout);

--- a/telemetry/layout-perf.py
+++ b/telemetry/layout-perf.py
@@ -22,7 +22,6 @@ from telemetry.internal.util import binary_manager
 from chrome_telemetry_build import chromium_config
 binary_manager.InitDependencyManager(chromium_config.ChromiumConfig().client_config)
 
-from telemetry.timeline import tracing_category_filter
 from telemetry.timeline import tracing_config
 
 from json import dumps
@@ -41,12 +40,11 @@ with browserFactory.Create(options) as browser:
       continue
     i.Close()
 
-  category_filter = tracing_category_filter.TracingCategoryFilter()
   config = tracing_config.TracingConfig()
   config.enable_chrome_trace = True
   tab.Navigate(args[0]);
   tab.WaitForDocumentReadyStateToBeComplete();
   tab.EvaluateJavaScript("(function() { document.documentElement.style.display = 'none'; return document.body.offsetTop; })()");
-  browser.platform.tracing_controller.Start(config, category_filter)
+  browser.platform.tracing_controller.Start(config)
   tab.EvaluateJavaScript("(function() { document.documentElement.style.display = 'block'; return document.body.offsetTop; })()");
   browser.platform.tracing_controller.Stop().Serialize(sys.stdout);

--- a/telemetry/newBrowser.py
+++ b/telemetry/newBrowser.py
@@ -100,14 +100,14 @@ with browserFactory.Create(options) as browser:
       category_filter = tracing_category_filter.TracingCategoryFilter(filter_string=filter_string)
       config = tracing_config.TracingConfig()
       config.enable_chrome_trace = True
-      browser.platform.tracing_controller.Start(config, category_filter)
+      browser.platform.tracing_controller.StartTracing(config, category_filter)
       if options.perf:
         browser.profiling_controller.Start('perf', '/tmp/erlnmyr-perf/profiling-results');
       sys.stdout.write('OK');
       sys.stdout.flush();
     elif command.startswith('endTracing'):
       sys.stderr.write('EndTrace');
-      data = browser.platform.tracing_controller.Stop();
+      data = browser.platform.tracing_controller.StopTracing();
       f = tempfile.NamedTemporaryFile();
       data.Serialize(f);
       f.flush();

--- a/telemetry/newBrowser.py
+++ b/telemetry/newBrowser.py
@@ -28,7 +28,7 @@ from chrome_telemetry_build import chromium_config
 binary_manager.InitDependencyManager(chromium_config.ChromiumConfig().client_config)
 
 from telemetry.timeline import tracing_category_filter
-from telemetry.timeline import tracing_options
+from telemetry.timeline import tracing_config
 
 from profile_chrome import trace_packager
 from telemetry.internal.platform import device_finder
@@ -98,9 +98,9 @@ with browserFactory.Create(options) as browser:
       if len(commandBits) > 1 and commandBits[1].startswith('filter:'):
         filter_string = commandBits[1][7:]
       category_filter = tracing_category_filter.TracingCategoryFilter(filter_string=filter_string)
-      tracing_options = tracing_options.TracingOptions()
-      tracing_options.enable_chrome_trace = True
-      browser.platform.tracing_controller.Start(tracing_options, category_filter);
+      config = tracing_config.TracingConfig()
+      config.enable_chrome_trace = True
+      browser.platform.tracing_controller.Start(config, category_filter)
       if options.perf:
         browser.profiling_controller.Start('perf', '/tmp/erlnmyr-perf/profiling-results');
       sys.stdout.write('OK');

--- a/telemetry/perf.py
+++ b/telemetry/perf.py
@@ -23,7 +23,7 @@ from chrome_telemetry_build import chromium_config
 binary_manager.InitDependencyManager(chromium_config.ChromiumConfig().client_config)
 
 from telemetry.timeline import tracing_category_filter
-from telemetry.timeline import tracing_options
+from telemetry.timeline import tracing_config
 
 from json import dumps
 
@@ -42,9 +42,9 @@ with browserFactory.Create(options) as browser:
     i.Close()
 
   category_filter = tracing_category_filter.TracingCategoryFilter()
-  options = tracing_options.TracingOptions()
-  options.enable_chrome_trace = True
-  browser.platform.tracing_controller.Start(options, category_filter);
+  config = tracing_config.TracingConfig()
+  config.enable_chrome_trace = True
+  browser.platform.tracing_controller.Start(config, category_filter)
   tab.Navigate(args[0]);
   tab.WaitForDocumentReadyStateToBeComplete();
   browser.platform.tracing_controller.Stop().Serialize(sys.stdout);

--- a/telemetry/perf.py
+++ b/telemetry/perf.py
@@ -22,7 +22,6 @@ from telemetry.internal.util import binary_manager
 from chrome_telemetry_build import chromium_config
 binary_manager.InitDependencyManager(chromium_config.ChromiumConfig().client_config)
 
-from telemetry.timeline import tracing_category_filter
 from telemetry.timeline import tracing_config
 
 from json import dumps
@@ -41,10 +40,9 @@ with browserFactory.Create(options) as browser:
       continue
     i.Close()
 
-  category_filter = tracing_category_filter.TracingCategoryFilter()
   config = tracing_config.TracingConfig()
   config.enable_chrome_trace = True
-  browser.platform.tracing_controller.Start(config, category_filter)
+  browser.platform.tracing_controller.Start(config)
   tab.Navigate(args[0]);
   tab.WaitForDocumentReadyStateToBeComplete();
   browser.platform.tracing_controller.Stop().Serialize(sys.stdout);

--- a/telemetry/perf.py
+++ b/telemetry/perf.py
@@ -42,7 +42,7 @@ with browserFactory.Create(options) as browser:
 
   config = tracing_config.TracingConfig()
   config.enable_chrome_trace = True
-  browser.platform.tracing_controller.Start(config)
+  browser.platform.tracing_controller.StartTracing(config)
   tab.Navigate(args[0]);
   tab.WaitForDocumentReadyStateToBeComplete();
-  browser.platform.tracing_controller.Stop().Serialize(sys.stdout);
+  browser.platform.tracing_controller.StopTracing().Serialize(sys.stdout);

--- a/telemetry/style-perf.py
+++ b/telemetry/style-perf.py
@@ -22,7 +22,6 @@ from telemetry.internal.util import binary_manager
 from chrome_telemetry_build import chromium_config
 binary_manager.InitDependencyManager(chromium_config.ChromiumConfig().client_config)
 
-from telemetry.timeline import tracing_category_filter
 from telemetry.timeline import tracing_config
 
 from json import dumps
@@ -41,11 +40,10 @@ with browserFactory.Create(options) as browser:
       continue
     i.Close()
 
-  category_filter = tracing_category_filter.TracingCategoryFilter()
   config = tracing_config.TracingConfig()
   config.enable_chrome_trace = True
   tab.Navigate(args[0]);
   tab.WaitForDocumentReadyStateToBeComplete();
-  browser.platform.tracing_controller.Start(config, category_filter)
+  browser.platform.tracing_controller.Start(config)
   tab.EvaluateJavaScript("(function() { document.documentElement.lang += 'z'; return getComputedStyle(document.body).color; })()");
   browser.platform.tracing_controller.Stop().Serialize(sys.stdout);

--- a/telemetry/style-perf.py
+++ b/telemetry/style-perf.py
@@ -44,6 +44,6 @@ with browserFactory.Create(options) as browser:
   config.enable_chrome_trace = True
   tab.Navigate(args[0]);
   tab.WaitForDocumentReadyStateToBeComplete();
-  browser.platform.tracing_controller.Start(config)
+  browser.platform.tracing_controller.StartTracing(config)
   tab.EvaluateJavaScript("(function() { document.documentElement.lang += 'z'; return getComputedStyle(document.body).color; })()");
-  browser.platform.tracing_controller.Stop().Serialize(sys.stdout);
+  browser.platform.tracing_controller.StopTracing().Serialize(sys.stdout);

--- a/telemetry/style-perf.py
+++ b/telemetry/style-perf.py
@@ -23,7 +23,7 @@ from chrome_telemetry_build import chromium_config
 binary_manager.InitDependencyManager(chromium_config.ChromiumConfig().client_config)
 
 from telemetry.timeline import tracing_category_filter
-from telemetry.timeline import tracing_options
+from telemetry.timeline import tracing_config
 
 from json import dumps
 
@@ -42,10 +42,10 @@ with browserFactory.Create(options) as browser:
     i.Close()
 
   category_filter = tracing_category_filter.TracingCategoryFilter()
-  options = tracing_options.TracingOptions()
-  options.enable_chrome_trace = True
+  config = tracing_config.TracingConfig()
+  config.enable_chrome_trace = True
   tab.Navigate(args[0]);
   tab.WaitForDocumentReadyStateToBeComplete();
-  browser.platform.tracing_controller.Start(options, category_filter);
+  browser.platform.tracing_controller.Start(config, category_filter)
   tab.EvaluateJavaScript("(function() { document.documentElement.lang += 'z'; return getComputedStyle(document.body).color; })()");
   browser.platform.tracing_controller.Stop().Serialize(sys.stdout);


### PR DESCRIPTION
The `tracing_options` module was merged into `tracing_config`, breaking
the scripts which depended on it.

References:

* https://codereview.chromium.org/1568993002
* https://codereview.chromium.org/1575503002